### PR TITLE
performance bugfix for big files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-VERSION = '0.4.0'
+VERSION = '0.4.1'
 
 setup(
     name='common_helper_unpacking_classifier',

--- a/src/common_helper_unpacking_classifier/average_entropy.py
+++ b/src/common_helper_unpacking_classifier/average_entropy.py
@@ -4,7 +4,6 @@ from typing import Callable
 
 from entropython import metric_entropy, shannon_entropy
 
-from .helper import _calculate_end_of_block
 
 BLOCKSIZE = 256
 
@@ -22,10 +21,9 @@ def avg_entropy(input_data: bytes, block_size: int = BLOCKSIZE, entropy_function
     entropy_sum = 0
     number_of_blocks = 0
     while offset < len(input_data):
-        end_of_block = _calculate_end_of_block(offset, block_size, len(input_data))
-        current_block = input_data[offset:end_of_block]
+        current_block = input_data[offset:offset + block_size]
         entropy_sum += entropy_function(current_block) * (len(current_block) / block_size)
-        offset = end_of_block
+        offset += block_size
         number_of_blocks += (len(current_block) / block_size)
     try:
         return entropy_sum / number_of_blocks

--- a/src/common_helper_unpacking_classifier/get_size.py
+++ b/src/common_helper_unpacking_classifier/get_size.py
@@ -5,9 +5,8 @@ import sys
 from common_helper_files import get_binary_from_file
 from entropython import metric_entropy as entropy
 
-from .helper import _calculate_end_of_block
 
-BLOCKSIZE = 4
+BLOCKSIZE = 256
 PADDING_ENTROPY_THRESHOLD = 0.1
 
 
@@ -51,8 +50,7 @@ def get_binary_size_without_padding(data: bytes, blocksize: int = BLOCKSIZE,
     padding_size = 0
     offset = 0
     while offset < original_size:
-        end_of_block = _calculate_end_of_block(offset, blocksize, original_size)
-        if entropy(data[offset:end_of_block]) <= padding_entropy_threshold:
+        if entropy(data[offset:offset + blocksize]) <= padding_entropy_threshold:
             padding_size += blocksize
-        offset = end_of_block
+        offset += blocksize
     return original_size - padding_size

--- a/src/common_helper_unpacking_classifier/helper.py
+++ b/src/common_helper_unpacking_classifier/helper.py
@@ -1,5 +1,0 @@
-def _calculate_end_of_block(current_offset, block_size, max_size):
-    result = current_offset + block_size
-    if result > max_size:
-        result = max_size
-    return result

--- a/src/tests/test_get_size.py
+++ b/src/tests/test_get_size.py
@@ -13,7 +13,6 @@ class TestGetSize(unittest.TestCase):
 
     def test_get_bin_size_without_padding(self):
         no_padding = b'abcdefgt'
-        self.assertEqual(get_binary_size_without_padding(no_padding), len(no_padding))
-        with_padding = b'abcd' + 4 * b'\x00' + b'abcd'
-        self.assertEqual(len(with_padding), 12)
-        self.assertEqual(get_binary_size_without_padding(with_padding), 8)
+        assert get_binary_size_without_padding(no_padding) == len(no_padding)
+        with_padding = os.urandom(4096) + b'\x00' * 1024 + os.urandom(4096)
+        assert get_binary_size_without_padding(with_padding) == 4096*2


### PR DESCRIPTION
- function `get_binary_size_without_padding` was running absurdly long for large files
- changed padding block size to speed up the function (may reduce padding detection precision)
- minor refactoring