### PR TITLE
increased avg entropy block size

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-VERSION = '0.4.1'
+VERSION = '0.4.2'
 
 setup(
     name='common_helper_unpacking_classifier',

--- a/src/common_helper_unpacking_classifier/average_entropy.py
+++ b/src/common_helper_unpacking_classifier/average_entropy.py
@@ -5,7 +5,7 @@ from typing import Callable
 from entropython import metric_entropy, shannon_entropy
 
 
-BLOCKSIZE = 256
+BLOCKSIZE = 4096
 
 
 def avg_entropy(input_data: bytes, block_size: int = BLOCKSIZE, entropy_function: Callable = metric_entropy) -> float:


### PR DESCRIPTION
- the result of the "avg_entropy" function doesn't go higher than 0.9 even for completely random data because of its small "block size" (the size of the individual blocks for which the entropy is calculated)
- increasing the block size from 256 to 4096 reduces this "error" from ~10% to ~0.5%