### PR TITLE
Get size: chunk iteration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "common_helper_unpacking_classifier"
-version = "0.5.0"
+version = "0.6.0"
 description = "Functions that help judge whether unpacking was successful."
 authors = [
     { name = "Fraunhofer FKIE", email = "peter.weidenbach@fkie.fraunhofer.de" }

--- a/src/common_helper_unpacking_classifier/average_entropy.py
+++ b/src/common_helper_unpacking_classifier/average_entropy.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 import logging
 from io import BufferedReader
 from pathlib import Path
-from typing import Callable, Iterable
+from typing import Callable
 
 from entropython import metric_entropy, shannon_entropy
+
+from .utils import iter_content_in_chunks
 
 BLOCKSIZE = 4096
 
@@ -25,7 +27,7 @@ def avg_entropy(
     """
     entropy_sum = 0
     number_of_blocks = 0
-    for block in _iter_content_in_chunks(input_data, block_size):
+    for block in iter_content_in_chunks(input_data, block_size):
         block_weight = len(block) / block_size
         entropy_sum += entropy_function(block) * block_weight
         number_of_blocks += block_weight
@@ -36,22 +38,6 @@ def avg_entropy(
     except Exception as err:
         logging.exception(f"Could not calculate entropy: {err}")
         return 0.0
-
-
-def _iter_content_in_chunks(
-    input_data: Path | bytes | BufferedReader,
-    chunk_size: int,
-) -> Iterable[bytes]:
-    if isinstance(input_data, Path):
-        with input_data.open("rb") as fp:
-            while chunk := fp.read(chunk_size):
-                yield chunk
-    elif isinstance(input_data, BufferedReader):
-        while chunk := input_data.read(chunk_size):
-            yield chunk
-    else:
-        for offset in range(0, len(input_data), chunk_size):
-            yield input_data[offset : offset + chunk_size]
 
 
 def avg_shannon_entropy(

--- a/src/common_helper_unpacking_classifier/get_size.py
+++ b/src/common_helper_unpacking_classifier/get_size.py
@@ -1,42 +1,44 @@
 from __future__ import annotations
 
 import logging
-import os
-import sys
 from pathlib import Path
+from typing import Iterable
 
-from common_helper_files import get_binary_from_file
 from entropython import metric_entropy as entropy
 
+from .utils import iter_content_in_chunks
 
 BLOCKSIZE = 256
 PADDING_ENTROPY_THRESHOLD = 0.1
 
 
-def get_file_size(file_path: str) -> int:
-    """
-    Returns the size of file in bytes. Returns zero on error.
-
-    :param file_path: path to file
-    :return: the size of file as number of bytes
-    """
-    try:
-        return os.path.getsize(file_path)
-    except Exception as err:
-        logging.error(f"Could not get file size: {sys.exc_info()[0].__name__} {err}")
-        return 0
+def get_file_size(file_path: str | Path) -> int:
+    logging.warning(
+        "Deprecation warning: this function is no longer supported. "
+        "Please use pathlib.Path.stat().st_size instead."
+    )
+    return Path(file_path).stat().st_size
 
 
-def get_file_size_without_padding(file_path: str | Path) -> int:
+def get_file_size_without_padding(
+    file_path: str | Path,
+    blocksize: int = BLOCKSIZE,
+    padding_entropy_threshold: float = PADDING_ENTROPY_THRESHOLD,
+) -> int:
     """
     Returns the size of file in bytes minus size of padding areas.
 
     :param file_path: path to file
-    :type file_path: str
+    :param blocksize: block-size regarding padding detection
+    :param padding_entropy_threshold: shannon entropy threshold regarding padding detection
     :return: int
     """
-    file_data = get_binary_from_file(file_path)
-    return get_binary_size_without_padding(file_data)
+    file_size = Path(file_path).stat().st_size
+    return _get_size_without_padding(
+        iter_content_in_chunks(file_path, blocksize),
+        file_size,
+        padding_entropy_threshold,
+    )
 
 
 def get_binary_size_without_padding(
@@ -52,11 +54,18 @@ def get_binary_size_without_padding(
     :param padding_entropy_threshold: shannon entropy threshold regarding padding detection
     :return: the size of input_data without padding
     """
-    original_size = len(data)
+    return _get_size_without_padding(
+        iter_content_in_chunks(data, blocksize), len(data), padding_entropy_threshold
+    )
+
+
+def _get_size_without_padding(
+    blocks: Iterable[bytes],
+    original_size: int,
+    entropy_threshold: float = PADDING_ENTROPY_THRESHOLD,
+) -> int:
     padding_size = 0
-    offset = 0
-    while offset < original_size:
-        if entropy(data[offset : offset + blocksize]) <= padding_entropy_threshold:
-            padding_size += blocksize
-        offset += blocksize
+    for block in blocks:
+        if entropy(block) <= entropy_threshold:
+            padding_size += len(block)
     return original_size - padding_size

--- a/src/common_helper_unpacking_classifier/get_size.py
+++ b/src/common_helper_unpacking_classifier/get_size.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
 import logging
 import os
 import sys
+from pathlib import Path
 
 from common_helper_files import get_binary_from_file
 from entropython import metric_entropy as entropy
@@ -11,46 +14,49 @@ PADDING_ENTROPY_THRESHOLD = 0.1
 
 
 def get_file_size(file_path: str) -> int:
-    '''
+    """
     Returns the size of file in bytes. Returns zero on error.
 
     :param file_path: path to file
     :return: the size of file as number of bytes
-    '''
+    """
     try:
         return os.path.getsize(file_path)
     except Exception as err:
-        logging.error('Could not get file size: {} {}'.format(sys.exc_info()[0].__name__, err))
+        logging.error(f"Could not get file size: {sys.exc_info()[0].__name__} {err}")
         return 0
 
 
-def get_file_size_without_padding(file_path: str) -> int:
-    '''
+def get_file_size_without_padding(file_path: str | Path) -> int:
+    """
     Returns the size of file in bytes minus size of padding areas.
 
     :param file_path: path to file
     :type file_path: str
     :return: int
-    '''
+    """
     file_data = get_binary_from_file(file_path)
     return get_binary_size_without_padding(file_data)
 
 
-def get_binary_size_without_padding(data: bytes, blocksize: int = BLOCKSIZE,
-                                    padding_entropy_threshold: float = PADDING_ENTROPY_THRESHOLD) -> int:
-    '''
+def get_binary_size_without_padding(
+    data: bytes,
+    blocksize: int = BLOCKSIZE,
+    padding_entropy_threshold: float = PADDING_ENTROPY_THRESHOLD,
+) -> int:
+    """
     Returns the size of input_data in bytes minus size of padding areas.
 
     :param data: input data
     :param blocksize: block-size regarding padding detection
     :param padding_entropy_threshold: shannon entropy threshold regarding padding detection
     :return: the size of input_data without padding
-    '''
+    """
     original_size = len(data)
     padding_size = 0
     offset = 0
     while offset < original_size:
-        if entropy(data[offset:offset + blocksize]) <= padding_entropy_threshold:
+        if entropy(data[offset : offset + blocksize]) <= padding_entropy_threshold:
             padding_size += blocksize
         offset += blocksize
     return original_size - padding_size

--- a/src/common_helper_unpacking_classifier/utils.py
+++ b/src/common_helper_unpacking_classifier/utils.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from io import BufferedReader
+from pathlib import Path
+from typing import Iterable
+
+
+def iter_content_in_chunks(
+    input_data: Path | bytes | BufferedReader,
+    chunk_size: int,
+) -> Iterable[bytes]:
+    if isinstance(input_data, Path):
+        with input_data.open("rb") as fp:
+            while chunk := fp.read(chunk_size):
+                yield chunk
+    elif isinstance(input_data, BufferedReader):
+        while chunk := input_data.read(chunk_size):
+            yield chunk
+    else:
+        for offset in range(0, len(input_data), chunk_size):
+            yield input_data[offset : offset + chunk_size]

--- a/src/tests/test_get_size.py
+++ b/src/tests/test_get_size.py
@@ -1,18 +1,9 @@
-import unittest
 import os
-from common_helper_unpacking_classifier.get_size import get_file_size, get_binary_size_without_padding
+from common_helper_unpacking_classifier.get_size import get_binary_size_without_padding
 
 
-class TestGetSize(unittest.TestCase):
-
-    def test_get_file_size(self):
-        none_existing_file = '/foo/nonexisting'
-        self.assertEqual(get_file_size(none_existing_file), 0)
-        existing_file = os.path.abspath(__file__)
-        self.assertGreater(get_file_size(existing_file), 1)
-
-    def test_get_bin_size_without_padding(self):
-        no_padding = b'abcdefgt'
-        assert get_binary_size_without_padding(no_padding) == len(no_padding)
-        with_padding = os.urandom(4096) + b'\x00' * 1024 + os.urandom(4096)
-        assert get_binary_size_without_padding(with_padding) == 4096*2
+def test_get_bin_size_without_padding():
+    no_padding = b'abcdefgt'
+    assert get_binary_size_without_padding(no_padding) == len(no_padding)
+    with_padding = os.urandom(4096) + b'\x00' * 1024 + os.urandom(4096)
+    assert get_binary_size_without_padding(with_padding) == 4096*2


### PR DESCRIPTION
- makes `iter_content_in_chunks` a utility function and also uses it in the `get_size` module
- deprecates the `get_file_size` method in favor of `pathlib.Path.stat().st_size`